### PR TITLE
Added subdirectory support for marker

### DIFF
--- a/src/client/containers/edit/EditMode.vue
+++ b/src/client/containers/edit/EditMode.vue
@@ -67,7 +67,7 @@ export default {
   methods: {
     updatesource() {
       this.source.hash = this.$project.setSource(this.selected.id, this.source.data);
-      this.html = this.$converter.convert(this.source.data);      
+      this.html = this.$converter.convert(this.selected.folder, this.source.data);      
     },
     updateproject() {      
       let pi = this.$project.getProjectInfo();
@@ -92,7 +92,7 @@ export default {
         this.project = pi;
         this.selected = selected;
         this.source = source;        
-        this.html = this.$converter.convert(source.data);  
+        this.html = this.$converter.convert(selected.folder, source.data);  
         
         if(selected.id != pi.selected) {
           this.$project.setSelected(selected.id);

--- a/src/client/containers/help/Debug.vue
+++ b/src/client/containers/help/Debug.vue
@@ -41,7 +41,7 @@ export default {
           if (selected) {
             let source = this.$project.getSource(selected.id);
             if(source) {
-              this.html = this.$converter.convert(source.data);  
+              this.html = this.$converter.convert(selected.folder, source.data);  
             } else {
               this.html = "no current source";  
             }

--- a/src/client/containers/print/Print.vue
+++ b/src/client/containers/print/Print.vue
@@ -231,7 +231,7 @@ export default {
         if(!source) {
           this.$router.replace("/home");  
         }
-        this.html = this.$converter.convert(source.data);  
+        this.html = this.$converter.convert(selected.folder, source.data);  
 
         if(selected.id != pi.selected) {
           this.$project.setSelected(selected.id);

--- a/src/client/containers/view/ViewMode.vue
+++ b/src/client/containers/view/ViewMode.vue
@@ -77,7 +77,8 @@ export default {
         if(pi.files) {  
           let files = [];
           let pifiles = pi.files.sort((a,b)=> {
-            return a.name.localeCompare(b.name);
+            return (a.folder.localeCompare(b.folder) * 1000000) + 
+            a.name.localeCompare(b.name);
           });
           pifiles.forEach(f => {
             let file = {
@@ -139,7 +140,9 @@ export default {
         let files = [];
         if(pi.files) {
           let pifiles = pi.files.sort((a,b)=> {
-            return a.name.localeCompare(b.name);
+            return (a.folder.localeCompare(b.folder) * 1000000) + 
+            a.name.localeCompare(b.name);
+
           });
           pifiles.forEach(f => {
             let file = {

--- a/src/client/containers/view/ViewMode.vue
+++ b/src/client/containers/view/ViewMode.vue
@@ -83,6 +83,7 @@ export default {
             let file = {
               id: f.id,
               name: f.name,
+              folder: f.folder,
               modified: f.modified,
               data: {
                 hash: -1,
@@ -144,6 +145,7 @@ export default {
             let file = {
               id: f.id,
               name: f.name,
+              folder: f.folder,
               modified: f.modified,
               data: {
                 hash: -1,
@@ -188,7 +190,7 @@ export default {
         if(source) {
           let data = {
             hash: source.hash,
-            html: this.$converter.convert(source.data)
+            html: this.$converter.convert(file.folder, source.data)
           };
           file.data = data;
           return true;

--- a/src/client/plugins/app-converter.js
+++ b/src/client/plugins/app-converter.js
@@ -13,10 +13,11 @@ appConverter.install = function (Vue, options) {
   this.log = Vue.$log;
 
   var service = {
-    convert(source) {   
+    convert(folder, source) {
       let result = ipcRenderer.sendSync('convert-command', {
         command: "convert",
-        source: source
+        source: source,
+        folder: folder
       });
       return result;
     }

--- a/src/host/handlers/receive/convert-command.handler.ts
+++ b/src/host/handlers/receive/convert-command.handler.ts
@@ -22,7 +22,8 @@ export class ConvertCommandReceiveHandler extends IConvertCommandReceiveHandler 
       let command: string = arg.command;
       if(command === "convert") {
         let source: string = arg.source;
-        let result = this._converterService.convert(source);
+        let folder: string = arg.folder;
+        let result = this._converterService.convert(folder,source);
         event.returnValue = result;
       }            
     }

--- a/src/host/services/converter/converter.service.ts
+++ b/src/host/services/converter/converter.service.ts
@@ -110,7 +110,10 @@ export class ConverterService extends IConverterService {
       renderer.link = function(href: string, title: string, text: string) {
         const linkUrl = url.parse(href);
         if(linkUrl && !linkUrl.protocol && curFolder) {
-          let link = path.join(folder, linkUrl.path);
+          let sublink = linkUrl.path;
+          let link = path.join(folder, sublink);
+          //A bit of magic to placate the Javascript gods.
+          link = link.replace(/\\/g, "/");
           href = `javascript:onclick('${link}')`;
         }
         return f_link.apply(this, [href, title, text]);

--- a/src/host/services/converter/converter.service.ts
+++ b/src/host/services/converter/converter.service.ts
@@ -59,11 +59,11 @@ export class ConverterService extends IConverterService {
     }
   }
   
-  convert(src: string): string {
+  convert(folder:string, src: string): string {
     this.log.debug("convert", "ConverterService.convert");
     try {
       const md = this.convertKatex(src);
-      const html = this.convertMarkdown(md);
+      const html = this.convertMarkdown(folder,md);
       return html;
     }
     catch (e) {
@@ -92,12 +92,13 @@ export class ConverterService extends IConverterService {
     }
   }
 
-  private convertMarkdown(src: string) : string {
+  private convertMarkdown(folder: string, src: string) : string {
     this.log.debug("converting markdown", "ConverterService.convertMarkdown");
     try {
       let renderer: any = new marked.Renderer();
       let that = this;
 
+      let curFolder : string = that._projectFolder+"/"+folder;
       //rennder anchors
       const f_heading  = renderer.heading;  
       renderer.heading  = function (text: string, level: number, raw: string) {
@@ -108,8 +109,9 @@ export class ConverterService extends IConverterService {
       const f_link = renderer.link;
       renderer.link = function(href: string, title: string, text: string) {
         const linkUrl = url.parse(href);
-        if(linkUrl && !linkUrl.protocol && that._projectFolder) {
-          href = `javascript:onclick('${linkUrl.path}')`;
+        if(linkUrl && !linkUrl.protocol && curFolder) {
+          let link = path.join(folder, linkUrl.path);
+          href = `javascript:onclick('${link}')`;
         }
         return f_link.apply(this, [href, title, text]);
       }
@@ -118,8 +120,8 @@ export class ConverterService extends IConverterService {
       const f_image = renderer.image;  
       renderer.image = function (href: string, title: string, text: string) {
         const imageUrl = url.parse(href);
-        if(imageUrl && !imageUrl.protocol && that._projectFolder) {
-          const fullpath = path.join(that._projectFolder, imageUrl.path);
+        if(imageUrl && !imageUrl.protocol && curFolder) {
+          const fullpath = path.join(curFolder, imageUrl.path);
           const fileUri = that.getFileUri(fullpath);
           if(title) {
             return `<img src="${fileUri}" title="${title}" alt="${text}">`;

--- a/src/host/services/converter/interfaces.ts
+++ b/src/host/services/converter/interfaces.ts
@@ -1,5 +1,5 @@
 export abstract class IConverterService {    
   abstract init(): void;
   abstract done(): void;
-  abstract convert(src: string): string;
+  abstract convert(folder: string, src: string): string;
 }

--- a/src/host/services/project/interfaces.ts
+++ b/src/host/services/project/interfaces.ts
@@ -7,6 +7,7 @@ export interface IProjectInfo {
   files: {
     id: string;
     name: string,
+    folder: string,
     modified: boolean;
     hash?: {
       file: number,

--- a/src/module/view/view.html
+++ b/src/module/view/view.html
@@ -12,8 +12,10 @@
   <div id="view"></div>
   <script>
     var electron = require('electron');
-    function onclick(url) {
+    function onclick( url) {
       try {
+        
+        alert(url);
         electron.ipcRenderer.send('project-command', {
           command: "try-navigate",
           url: url

--- a/src/module/view/view.html
+++ b/src/module/view/view.html
@@ -12,10 +12,9 @@
   <div id="view"></div>
   <script>
     var electron = require('electron');
-    function onclick( url) {
+    function onclick(url) {
       try {
         
-        alert(url);
         electron.ipcRenderer.send('project-command', {
           command: "try-navigate",
           url: url


### PR DESCRIPTION
- When opening a file or folder, not only the current directory but also all of the subdirectories are scanned for .MD files, and added to the list.
- Image and Link file locations are re-evaluated to work correctly.
- Changed the sorting a little bit so that files in the opened directory (as opposed to subdirectories) always shows up first.

For later:
- I'd like to make 'folders' and 'files' separate so that we can show a proper tree.